### PR TITLE
refactor toggle subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For example, using [`skhd`](https://github.com/koekeishiya/skhd):
 
 ```zsh
 # Toggle WezTerm with ⇧⌘C
-shift + cmd - t: MacOSUtility toggle 'WezTerm'
+shift + cmd - t: MacOSUtility toggle --name=WezTerm --bundle-id='com.github.wez.wezterm'
 # Toggle Visual Studio Code with ⇧⌘A
-shift + cmd - a: MacOSUtility toggle 'Visual Studio Code' --process=Code
+shift + cmd - a: MacOSUtility toggle --name=Code --bundle-id='com.microsoft.VSCode'
 ```

--- a/Sources/CLI.swift
+++ b/Sources/CLI.swift
@@ -1,22 +1,16 @@
-import AppKit
 import ArgumentParser
-import CoreGraphics
-import Foundation
 import Logging
 
 @main
 struct CLI: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A utility for interacting with macOS via the terminal.",
-
         subcommands: [Toggle.self],
-        // A default subcommand, when provided, is automatically selected if a
-        // subcommand is not given on the command line.
         defaultSubcommand: Toggle.self)
 }
 
 struct Options: ParsableArguments {
-    @Flag(help: "Print debug information to stdout")
+    @Flag(name: .shortAndLong, help: "Print debug information to stdout")
     var verbose = false
 }
 
@@ -24,106 +18,23 @@ extension CLI {
     struct Toggle: ParsableCommand {
         static let configuration = CommandConfiguration(
             abstract:
-                "Toggle an application (hide it if it's active; otherwise launch/activate it)."
-        )
+                "Toggle an application (hide it if it's active; otherwise launch/activate it).")
 
-        @Argument(help: "The Application to toggle.")
-        var application: String
+        @Option(name: .shortAndLong, help: "The name of the Application.")
+        var name: String
 
-        @Option(help: "The process name the Application runs under.")
-        var process: String? = nil
+        @Option(name: .shortAndLong, help: "The Bundle ID of the Application.")
+        var bundleId: String
 
         @OptionGroup var options: Options
 
         mutating func run() throws {
-            print(
-                "application: String{ \(application) } options: Bool{ verbose: Bool{ \(options.verbose) } }"
-            )
+            print("Toggle command called: \(self)")
 
-            var logger: Logger = Logger(label: "ccb012100.MacOSUtility.CLI")
+            var logger: Logger = Logger(label: "com.github.ccb012100.MacOSUtility.CLI")
             if options.verbose { logger.logLevel = .debug }
 
-            switchToApp(named: application, process: process, logger: logger)
+            toggleApp(named: name, withBundleId: bundleId, withLogger: logger)
         }
     }
-}
-
-/// Toggle an Application by name
-///
-/// - If the Application is the active Application, hide it.
-/// - If the Application is running but not the active Application, activate it.
-/// - If the Application is not running, launch it.
-///
-/// - Remark: [source](https://stackoverflow.com/a/47264136)
-func switchToApp(
-    named appName: String, process processName: String? = nil, logger: Logger, dryRun: Bool = false
-) {
-    let options = CGWindowListOption(
-        arrayLiteral: CGWindowListOption.excludeDesktopElements,
-        CGWindowListOption.optionOnScreenOnly)
-
-    guard
-        let windowInfoList = CGWindowListCopyWindowInfo(options, CGWindowID(0)) as NSArray?
-            as? [[String: AnyObject]]
-    else {
-        renderNotification(message: "Unable to convert windowListInfo to array", isError: true)
-        return
-    }
-    logger.debug("Foo")
-
-    if let window = windowInfoList.first(where: {
-        ($0["kCGWindowOwnerName"] as? String)?.contains(processName ?? appName) ?? false
-    }), let pid = window["kCGWindowOwnerPID"] as? Int32 {  // application is running; get its pid
-        let app = NSRunningApplication(processIdentifier: pid)
-
-        if app == nil {  // failed to get app by pid
-            let errorMsg = "Unable to get application with pid \"\(pid)\"!"
-            logger.error("\(errorMsg)")
-            renderNotification(message: errorMsg, isError: true)
-        } else {
-            logger.debug("App '\(appName)' is running.")
-
-            if app!.isActive {  // app is the Active application
-                logger.debug("'\(appName)' is active. Attempting to hide it...")
-                app?.hide()
-            } else if !app!.activate(options: .activateIgnoringOtherApps) {  // try to activate the application
-                let errorMsg = "Failed to activate '\(appName)'."
-                logger.error("\(errorMsg)")
-                renderNotification(message: errorMsg, isError: true)
-            }
-        }
-    } else {
-        logger.debug("App '\(appName)' is not running. Attempting to launch it...")
-        if !NSWorkspace.shared.launchApplication(appName) {  // try to launch the application
-            // TODO: launchApplication is deprecated
-            let errorMsg = "Unable to launch application \"\(appName)\"!"
-            logger.error("\(errorMsg)")
-            renderNotification(message: errorMsg, isError: true)
-        }
-    }
-}
-
-/// Trigger a persistent System Notification
-///
-/// - Parameters
-///     - message: The Notification's body
-///     - isError:
-///         - `true` if the notification is an error message;
-///         - `false` if the message is solely informational
-func renderNotification(message: String, isError: Bool) {
-    // display for 5 seconds
-    let elements: [CFString: NSObject] = [
-        kCFUserNotificationAlertTopMostKey: 1 as NSNumber,
-        kCFUserNotificationAlertHeaderKey: "MacOSUtility\( isError ? " Error" : "")" as NSString,  // title
-        kCFUserNotificationAlertMessageKey: message as NSString,
-    ]
-
-    var error: Int32 = 0
-    CFUserNotificationCreate(
-        nil,
-        0,
-        isError ? kCFUserNotificationCautionAlertLevel : kCFUserNotificationPlainAlertLevel, &error,
-        elements as CFDictionary)
-
-    if error != 0 { fatalError("Unable to display notification dialog") }
 }

--- a/Sources/Notification.swift
+++ b/Sources/Notification.swift
@@ -1,0 +1,34 @@
+import AppKit
+import Logging
+
+func logErrorAndNotify(_ logger: Logger, withMessage message: String) {
+    logger.error("\(message)")
+    renderNotification(message: message, showAsError: true)
+}
+
+/// Trigger a persistent System Notification
+///
+/// - Parameters
+///     - message: The Notification's body
+///     - isError:
+///         - `true` if the notification is an error message;
+///         - `false` if the message is solely informational
+func renderNotification(message: String, showAsError: Bool) {
+    // display for 5 seconds
+    let elements: [CFString: NSObject] = [
+        kCFUserNotificationAlertTopMostKey: 1 as NSNumber,
+        kCFUserNotificationAlertHeaderKey: "MacOSUtility\( showAsError ? " Error" : "")"  // notification title
+            as NSString,
+        kCFUserNotificationAlertMessageKey: message as NSString,
+    ]
+
+    var error: Int32 = 0
+    CFUserNotificationCreate(
+        nil,
+        0,
+        showAsError ? kCFUserNotificationCautionAlertLevel : kCFUserNotificationPlainAlertLevel,
+        &error,
+        elements as CFDictionary)
+
+    if error != 0 { fatalError("Unable to display notification dialog") }
+}

--- a/Sources/Toggle.swift
+++ b/Sources/Toggle.swift
@@ -1,0 +1,43 @@
+import AppKit
+import Logging
+
+/// Toggle an Application between hidden and active
+///
+/// - If the Application is the active Application, hide it.
+/// - If the Application is running but not the active Application, bring it to the front.
+/// - If the Application is not running, launch it.
+func toggleApp(named appName: String, withBundleId bundleId: String, withLogger logger: Logger) {
+    let app = NSWorkspace.shared.runningApplications.first { $0.bundleIdentifier == bundleId }
+
+    if app != nil {
+        // app is running
+        if app!.isActive {
+            app!.hide()
+            // TODO: for some reason, app.hide() always returns false
+            // if !app!.hide() {
+            //     logErrorAndNotify(
+            //         logger,
+            //         withMessage: "Unable to hide app with Bundle Id \"\(bundleId)\"!")
+            // }
+        } else {
+            app!.activate()
+            if !app!.activate() {
+                logErrorAndNotify(
+                    logger,
+                    withMessage: "Unable to activate app with Bundle Id \"\(bundleId)\"!")
+            }
+        }
+    } else {
+        // app is not running
+        guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId)
+        else {
+            logErrorAndNotify(
+                logger,
+                withMessage: "Unable to get application URL for Bundle Id \"\(bundleId)\"!")
+            return
+        }
+
+        NSWorkspace.shared.openApplication(
+            at: appURL, configuration: NSWorkspace.OpenConfiguration())
+    }
+}


### PR DESCRIPTION
- using openApplication() because launchApplication() is deprecated
- using NSWorkspace.shared.runningApplications instead of the windowInfoList code I got off StackOverflow for much cleaner, slimmer code